### PR TITLE
Remove exported env vars with paths to work cert files

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -3,7 +3,6 @@ source $HOME/.profile
 export MANPAGER='nvim +Man!'
 
 . "$HOME/.cargo/env"
-export NODE_OPTIONS=--use-openssl-ca
 
 # Lua language server for neovim
 export PATH=$PATH:$HOME/.local/language-servers/lua.ls


### PR DESCRIPTION
Use direnv and .envrc files instead